### PR TITLE
Handle different platform line breaks.

### DIFF
--- a/src/Assets/SimpleSRT/SRTParser.cs
+++ b/src/Assets/SimpleSRT/SRTParser.cs
@@ -24,7 +24,7 @@ public class SRTParser
       return;
     }
 
-    var lines = textAsset.text.Split(new[] { "\r\n" }, StringSplitOptions.None);
+    var lines = textAsset.text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
     var currentState = eReadState.Index;
 


### PR DESCRIPTION
After building an SRT in Aegisub on the Mac, this code wouldn't parse it. It turned out to be a line break issue, which I fixed simply by adding more flexible line splitting.