### PR TITLE
RST-Parser improvements

### DIFF
--- a/src/Assets/SimpleSRT/SRTParser.cs
+++ b/src/Assets/SimpleSRT/SRTParser.cs
@@ -32,7 +32,7 @@ public class SRTParser
 
     int currentIndex = 0;
     double currentFrom = 0, currentTo = 0;
-    var currentText = "";
+    var currentText = string.Empty;
     for (var l = 0; l < lines.Length; l++)
     {
       var line = lines[l];
@@ -73,6 +73,9 @@ public class SRTParser
           break;
         case eReadState.Text:
           {
+			if (currentText != string.Empty)
+				currentText += "\r\n";
+
             currentText += line;
 
             // When we hit an empty line, consider it the end of the text

--- a/src/Assets/SimpleSRT/SRTParser.cs
+++ b/src/Assets/SimpleSRT/SRTParser.cs
@@ -13,22 +13,22 @@ public class SRTParser
 
   public SRTParser(TextAsset textAsset)
   {
-    Load(textAsset);
+    this._subtitles = Load(textAsset);
   }
 
-  void Load(TextAsset textAsset)
+  static public List<SubtitleBlock> Load(TextAsset textAsset)
   {
     if (textAsset == null)
     {
       Debug.LogError("Subtitle file is null");
-      return;
+      return null;
     }
 
     var lines = textAsset.text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
     var currentState = eReadState.Index;
 
-    _subtitles = new List<SubtitleBlock>();
+    var subs = new List<SubtitleBlock>();
 
     int currentIndex = 0;
     double currentFrom = 0, currentTo = 0;
@@ -79,7 +79,7 @@ public class SRTParser
             if (string.IsNullOrEmpty(line) || l == lines.Length - 1)
             {
               // Create the SubtitleBlock with the data we've aquired 
-              _subtitles.Add(new SubtitleBlock(currentIndex, currentFrom, currentTo, currentText));
+              subs.Add(new SubtitleBlock(currentIndex, currentFrom, currentTo, currentText));
 
               // Reset stuff so we can start again for the next block
               currentText = string.Empty;
@@ -89,6 +89,7 @@ public class SRTParser
           break;
       }
     }
+	return subs;
   }
 
   public SubtitleBlock GetForTime(float time)


### PR DESCRIPTION
Hi, I've been using this parser in a project, and here are some improvements I needed to make, in order to meet my needs.

### Preserving multiline subtitles-block
Line-breaks were holding very importants  informations in the srt I used.  
Currently, the parser would remove every-single line-breaks; I made sure it would preserve them. Out of simplicity, I defaulted them all to CRLF.

### Getting the subs as a List<> directly.
In didn't need to display any subtitles, all I needed was the srt-parsing bits. I wasn't really interested either in the way SRTParser objects delivered the subtitle-blocks. Since it's only a wrapper for a List, I changed `SRTParser.Load` into a static function that will return a list of SubtitleBlock directly, instead of a SRTParser object. (SRTParser objects can still be created the usual way and preserve the functionality you gave them.)

(On a side note, I actually went straight for `SRTParser.cs` and only imported this single file into my project, I think this class could use a little advertising on the main readme.)